### PR TITLE
Add "improve this page" links to sections

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -36,12 +36,9 @@ module.exports = {
     const contents = fs.readFileSync(filePath, "utf8");
     const regex = /import ([a-z0-9]+) from "\.\.\/[^."]+"/gim;
     const uses = (contents.match(regex) || []).map(x => x.replace(regex, "$1"));
-    const relativeSrcPath = filePath.match(/(src\/components.+)/)[0];
-    const githubSrcUrl = `https://github.com/diegohaz/reakit/tree/master/${relativeSrcPath}`;
     return {
       ...docs,
-      uses,
-      githubSrcUrl
+      uses
     };
   },
   updateExample(props) {

--- a/website/src/pages/Section.js
+++ b/website/src/pages/Section.js
@@ -3,12 +3,14 @@ import { styled, Block, Heading, Link } from "reakit";
 import { prop } from "styled-tools";
 import { Redirect } from "react-router-dom";
 import OpenInNewIcon from "react-icons/lib/md/open-in-new";
+import EditIcon from "react-icons/lib/md/edit";
 import StyleguidistContainer from "../containers/StyleguidistContainer";
 import Playground from "../components/Playground";
 import Markdown from "../components/Markdown";
 import findSectionByLocation from "../utils/findSectionByLocation";
 import getSectionContent from "../utils/getSectionContent";
 import getSectionUrl from "../utils/getSectionUrl";
+import getSectionGithubSrcUrl from "../utils/getSectionGithubSrcUrl";
 import findNonEmptySiblingSection from "../utils/findNonEmptySiblingSection";
 import SectionUses from "../components/SectionUses";
 
@@ -28,6 +30,7 @@ const Name = styled(Heading)`
 
 const GithubSrcLink = styled(Link)`
   margin-bottom: 0.35em;
+  display: block;
   @media (max-width: 768px) {
     padding: 0 8px;
   }
@@ -57,18 +60,25 @@ const Section = ({ location, ...props }) => (
     {({ sections }) => {
       const section = findSectionByLocation(sections, location);
       const sectionContent = getSectionContent(section);
+      const githubDocUrl = getSectionGithubSrcUrl(section, "doc");
+      const githubSrcUrl = getSectionGithubSrcUrl(section, "component");
       if (sectionContent) {
         return (
           <Wrapper {...props}>
             <Name>{section.name}</Name>
-            {section.props.githubSrcUrl && (
-              <GithubSrcLink href={section.props.githubSrcUrl} target="_blank">
-                View source on GitHub <OpenInNewIcon />
-              </GithubSrcLink>
-            )}
             {section.name !== "Base" && <StyledSectionUses section={section} />}
             {section.name !== "Base" && (
               <StyledSectionUses usedBy section={section} />
+            )}
+            {githubSrcUrl && (
+              <GithubSrcLink href={githubSrcUrl} target="_blank">
+                <OpenInNewIcon /> View source on GitHub
+              </GithubSrcLink>
+            )}
+            {githubDocUrl && (
+              <GithubSrcLink href={githubDocUrl} target="_blank">
+                <EditIcon /> Improve this page
+              </GithubSrcLink>
             )}
             <Content>
               {sectionContent.map(

--- a/website/src/utils/__tests__/getSectionGithubSrcUrl-test.js
+++ b/website/src/utils/__tests__/getSectionGithubSrcUrl-test.js
@@ -1,0 +1,43 @@
+import getSectionGithubSrcUrl from "../getSectionGithubSrcUrl";
+
+describe("getSectionGithubSrcUrl", () => {
+  test("with no filepath", () => {
+    const section = {
+      name: "Components"
+    };
+
+    expect(getSectionGithubSrcUrl(section, "doc")).toEqual(null);
+  });
+
+  describe("guide section", () => {
+    const section = {
+      name: "Composability",
+      filepath: "docs/composability.md"
+    };
+    test("returns the doc url", () => {
+      expect(getSectionGithubSrcUrl(section, "doc")).toEqual(
+        "https://github.com/diegohaz/reakit/tree/master/docs/composability.md"
+      );
+    });
+    test("does not return a component url", () => {
+      expect(getSectionGithubSrcUrl(section, "component")).toEqual(null);
+    });
+  });
+
+  describe("component section", () => {
+    const section = {
+      name: "Base",
+      filepath: "src/components/Base/Base.js"
+    };
+    test("returns the doc url", () => {
+      expect(getSectionGithubSrcUrl(section, "doc")).toEqual(
+        "https://github.com/diegohaz/reakit/tree/master/src/components/Base/Base.md"
+      );
+    });
+    test("does not return a component url", () => {
+      expect(getSectionGithubSrcUrl(section, "component")).toEqual(
+        "https://github.com/diegohaz/reakit/tree/master/src/components/Base/Base.js"
+      );
+    });
+  });
+});

--- a/website/src/utils/__tests__/isComponentSection-test.js
+++ b/website/src/utils/__tests__/isComponentSection-test.js
@@ -1,0 +1,29 @@
+import isComponentSection from "../isComponentSection";
+
+describe("isComponentSection", () => {
+  test("with no filepath", () => {
+    const section = {
+      name: "Components"
+    };
+
+    expect(isComponentSection(section)).toBe(false);
+  });
+
+  test("guide section", () => {
+    const section = {
+      name: "Composability",
+      filepath: "docs/composability.md"
+    };
+
+    expect(isComponentSection(section)).toBe(false);
+  });
+
+  test("component section", () => {
+    const section = {
+      name: "Base",
+      filepath: "src/components/Base/Base.js"
+    };
+
+    expect(isComponentSection(section)).toBe(true);
+  });
+});

--- a/website/src/utils/getSectionGithubSrcUrl.js
+++ b/website/src/utils/getSectionGithubSrcUrl.js
@@ -1,0 +1,35 @@
+import isComponentSection from "./isComponentSection";
+
+const ROOT = "https://github.com/diegohaz/reakit/tree/master";
+
+const TYPE_OPTIONS = ["component", "doc"];
+
+const EXTENSIONS = {
+  component: "js",
+  doc: "md"
+};
+
+/**
+ * Generates a github url for the source of a given section. This could be to the documentation
+ * markdown file, or the source file of a given component.
+ * @param {Object} section The styleguidest section
+ * @param {"component"|"doc"} type What to link to. the component source, or the markdown documentation source?
+ */
+export default function getComponentGithubSrcUrl(section, type) {
+  if (TYPE_OPTIONS.indexOf(type) === -1) {
+    throw new Error("Invalid source type, must be one of 'component' or 'doc'");
+  }
+
+  if (!section.filepath) {
+    return null;
+  }
+
+  if (type === "component" && !isComponentSection(section)) {
+    return null;
+  }
+
+  const filePathWithoutExtension = section.filepath.split(".")[0];
+  const newExtension = EXTENSIONS[type];
+
+  return `${ROOT}/${filePathWithoutExtension}.${newExtension}`;
+}

--- a/website/src/utils/isComponentSection.js
+++ b/website/src/utils/isComponentSection.js
@@ -1,0 +1,5 @@
+export default function isComponentSection(section) {
+  return Boolean(
+    section.filepath && section.filepath.startsWith("src/components")
+  );
+}


### PR DESCRIPTION
closes #112 

This also restructures the changes from #120 

I'm not sure which icon placement I like better, I went with the icon on the left ultimately.

<img width="474" alt="capture d ecran 2018-07-06 10 00 40" src="https://user-images.githubusercontent.com/555044/42391208-73e60f0a-8103-11e8-9573-f6c14c45bab4.png">

<img width="375" alt="capture d ecran 2018-07-06 09 55 37" src="https://user-images.githubusercontent.com/555044/42391167-55a3c208-8103-11e8-977e-5dddbc2c1edf.png">

<img width="1033" alt="capture d ecran 2018-07-06 09 54 59" src="https://user-images.githubusercontent.com/555044/42391173-5b2ad914-8103-11e8-8e26-327711f1a2df.png">
