### PR TITLE
Use angle instead of reverse prop on Perpendicular

### DIFF
--- a/src/components/Perpendicular/Perpendicular.js
+++ b/src/components/Perpendicular/Perpendicular.js
@@ -21,9 +21,9 @@ const perpendicularOpposite = props => opposites[perpendicular(props)];
 
 const isVertical = ({ pos }) => pos === "left" || pos === "right";
 
-const rotation = ({ rotate, pos, reverse }) => {
+const rotation = ({ rotate, pos, angle }) => {
   if (!rotate) return null;
-  const rotateZ = value => `rotateZ(${reverse ? value + 180 : value}deg)`;
+  const rotateZ = value => `rotateZ(${value + angle}deg)`;
   const rotations = {
     top: rotateZ(0),
     right: rotateZ(90),
@@ -92,13 +92,14 @@ Perpendicular.propTypes = {
   align: PropTypes.oneOf(["start", "center", "end"]),
   gutter: PropTypes.string,
   rotate: PropTypes.bool,
-  reverse: PropTypes.bool
+  angle: PropTypes.number
 };
 
 Perpendicular.defaultProps = {
   pos: "right",
   align: "center",
-  gutter: "0.75rem"
+  gutter: "0.75rem",
+  angle: 0
 };
 
 export default as("div")(Perpendicular);

--- a/src/components/Popover/PopoverArrow.js
+++ b/src/components/Popover/PopoverArrow.js
@@ -21,7 +21,7 @@ PopoverArrow.defaultProps = {
   align: "center",
   gutter: "0px",
   rotate: true,
-  reverse: true
+  angle: 180
 };
 
 export default as("div")(PopoverArrow);

--- a/src/components/Tooltip/TooltipArrow.js
+++ b/src/components/Tooltip/TooltipArrow.js
@@ -19,7 +19,7 @@ TooltipArrow.defaultProps = {
   align: "center",
   gutter: "0px",
   rotate: true,
-  reverse: true
+  angle: 180
 };
 
 export default as("div")(TooltipArrow);

--- a/website/src/components/PropTypesTable.js
+++ b/website/src/components/PropTypesTable.js
@@ -107,7 +107,7 @@ const PropTypesTable = ({ section }) =>
                                   <Table.Cell>
                                     {defaultValue && (
                                       <StyledCode>
-                                        {defaultValue.value}
+                                        {JSON.stringify(defaultValue.value)}
                                       </StyledCode>
                                     )}
                                   </Table.Cell>

--- a/website/src/utils/findSectionPropTypes.js
+++ b/website/src/utils/findSectionPropTypes.js
@@ -1,15 +1,22 @@
+/* eslint-disable react/forbid-foreign-prop-types */
 import parsePropTypes from "parse-prop-types";
 import findSectionUses from "./findSectionUses";
 
-const findSectionPropTypes = (sections, section) => ({
-  ...findSectionUses(sections, section).reduce(
-    (acc, usedSection) => ({
-      ...acc,
-      ...findSectionPropTypes(sections, usedSection)
-    }),
-    {}
-  ),
-  [section.name]: parsePropTypes(section.module.default)
-});
+const findSectionPropTypes = (sections, section, defaultProps) => {
+  const { default: component } = section.module;
+  return {
+    ...findSectionUses(sections, section).reduce(
+      (acc, usedSection) => ({
+        ...acc,
+        ...findSectionPropTypes(sections, usedSection, component.defaultProps)
+      }),
+      {}
+    ),
+    [section.name]: parsePropTypes({
+      propTypes: component.propTypes,
+      defaultProps: { ...component.defaultProps, ...defaultProps }
+    })
+  };
+};
 
 export default findSectionPropTypes;


### PR DESCRIPTION
Fix #109

I also changed `findSectionPropTypes` to display `defaultValues` from the parent component to the base component (e.g. https://deploy-preview-149--reakit.netlify.com/components/arrow shows `angle=0`, while https://deploy-preview-149--reakit.netlify.com/components/popover/popoverarrow shows `angle=180`)