### PR TITLE
Add 404 page to website

### DIFF
--- a/website/src/images/404.svg
+++ b/website/src/images/404.svg
@@ -1,0 +1,80 @@
+<svg width="387" height="219" viewBox="0 0 387 219" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(323.262 162.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(354.058 162.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(323 145)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(261.262 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(292.058 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(261 73)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(292.262 108.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(323.058 108.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(292 91)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(323.262 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(354.058 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(323 109)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(261.262 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(292.058 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(261 37)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(323.262 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(354.058 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(323 73)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(261.262 18.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(292.058 18.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(261 1)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(323.262 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(354.058 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(323 37)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(131.262 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(162.058 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(131 109)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(162.262 144.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(193.058 144.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(162 127)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(193.262 162.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(224.058 162.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(193 145)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(193.262 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(224.058 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(193 109)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(131.262 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(162.058 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(131 73)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(193.262 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(224.058 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(193 73)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(131.262 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(162.058 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(131 37)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(131.262 18.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(162.058 18.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(131 1)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(162.262 36.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(193.058 36.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(162 19)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(193.262 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(224.058 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(193 37)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(63.262 162.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(94.0583 162.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(63 145)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(1.26196 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(32.0583 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(1 73)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(32.262 108.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(63.0583 108.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(32 91)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(63.262 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(94.0583 126.899)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(63 109)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(1.26196 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(32.0583 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(1 37)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(63.262 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(94.0583 90.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(63 73)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(1.26196 18.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(32.0583 18.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(1 1)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 36.7292L31.6497 55.1013V18.3646L0 0V36.7292Z" transform="translate(63.262 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M0 18.3646L31.6497 0V36.7292L0 55.1013V18.3646Z" transform="translate(94.0583 54.8987)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+<path d="M31.485 0L63 18.2517L31.515 36.5561L0 18.3044L31.485 0Z" transform="translate(63 37)" fill="white" stroke="#282B36" stroke-width="2" stroke-linejoin="bevel"/>
+</svg>

--- a/website/src/pages/NotFound.js
+++ b/website/src/pages/NotFound.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { styled, Image } from "reakit";
+import { Helmet } from "react-helmet";
+import CoreLayout from "../layouts/CoreLayout";
+import ContentWrapper from "../elements/ContentWrapper";
+import svg404 from "../images/404.svg";
+
+const StyledWrapper = styled(ContentWrapper)`
+  justify-content: center;
+  margin: 100px 0 0;
+`;
+
+const NotFound = () => (
+  <CoreLayout>
+    <Helmet>
+      <title>Not Found - ReaKit</title>
+    </Helmet>
+    <StyledWrapper>
+      <Image src={svg404} alt="404" />
+    </StyledWrapper>
+  </CoreLayout>
+);
+
+export default NotFound;

--- a/website/src/pages/Sections.js
+++ b/website/src/pages/Sections.js
@@ -5,7 +5,9 @@ import Menu from "../components/Menu";
 import StyleguidistContainer from "../containers/StyleguidistContainer";
 import CoreLayout from "../layouts/CoreLayout";
 import ContentWrapper from "../elements/ContentWrapper";
+import findSectionByLocation from "../utils/findSectionByLocation";
 import Section from "./Section";
+import NotFound from "./NotFound";
 
 const getSlug = pathname => pathname.split("/")[1];
 
@@ -35,6 +37,12 @@ const Sections = ({ location, match }) => (
   <StyleguidistContainer>
     {({ sections }) => {
       const section = sections.find(s => s.slug === getSlug(location.pathname));
+      const matchedSection = findSectionByLocation(sections, location);
+
+      if (!matchedSection) {
+        return <NotFound />;
+      }
+
       return (
         <CoreLayout>
           <Content>


### PR DESCRIPTION
Ref #137 

It adds a 404 page to website if not match any section:
![image](https://user-images.githubusercontent.com/3277185/42857181-3359701a-8a1f-11e8-9872-e6be954723c9.png)

Notes:
1. I added `404.svg` to a new folder called `images` because I did not know where to put it :sweat_smile: 
2. Feel free to change `404.svg`, I'm not a designer, but I tried to give my best.
3. I did not put any text or call to action, if you think it's cool to have, suggest here.